### PR TITLE
mobile release page padding

### DIFF
--- a/js/web/components/Release.js
+++ b/js/web/components/Release.js
@@ -114,7 +114,7 @@ const ReleaseWrapper = styled(Box)(({ theme }) => ({
   display: "flex",
   [theme.breakpoints.down("md")]: {
     overflowX: "scroll",
-    paddingTop: "100px",
+    padding: "120px 0",
     "&::-webkit-scrollbar": {
       display: "none",
     },


### PR DESCRIPTION
- add 120px to top and bottom of `ReleaseWrapper` on mobile